### PR TITLE
Fix prism xallocater case in libc and mrubyc.

### DIFF
--- a/include/prism_xallocator.h
+++ b/include/prism_xallocator.h
@@ -17,6 +17,11 @@
 #elif defined(MRC_TARGET_MRUBYC)
   #include "mrubyc.h"
   #if defined(MRBC_ALLOC_LIBC)
+    #define xmalloc(size)             malloc(size)
+    #define xcalloc(nmemb,size)       calloc(nmemb, size)
+    #define xrealloc(nmemb,size)      realloc(nmemb, size)
+    #define xfree(ptr)                free(ptr)
+
     #define mrc_malloc(c,size)        malloc(size)
     #define mrc_calloc(c,nmemb,size)  calloc(nmemb, size)
     #define mrc_realloc(c,ptr,size)   realloc(ptr, size)


### PR DESCRIPTION
An error was occurring in lib/prism/src/diagnostic.c when both `MRC_TARGET_MRUBYC` and `MRBC_ALLOC_LIBC` were defined (including picoruby default builds).

Added missing xallocator definitions.