### PR TITLE
Fix a bug in the overflow check for negative values

### DIFF
--- a/src/codegen_prism.inc
+++ b/src/codegen_prism.inc
@@ -1792,7 +1792,9 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
             mrc_uint value = ((mrc_uint)cast->value.values[0])|((mrc_uint)cast->value.values[1] << 32);
             if (!cast->value.negative && MRC_INT_MAX < value) goto overflow;
             if (cast->value.negative) {
-              if (value < MRC_INT_MIN) goto overflow;
+              // `value` is the unsigned absolute value of the negative literal.
+              //  (mrc_uint)MRC_INT_MIN wraps -2^63 to 2^63, which is the max absolute value a negative mrc_int can represent.
+              if (value > (mrc_uint)MRC_INT_MIN) goto overflow;
               value *= -1;
             }
             gen_int(s, cursp(), value);


### PR DESCRIPTION
Currently, the maximum value for a 64-bit integer, `9223372036854775807`, is compiled as `IREP_TT_INT64`,
but the minimum value, `-9223372036854775808`, is compiled as a `IREP_TT_BIGINT`.

I have corrected the logic because this is considered a bug in the negative overflow check.