### PR TITLE
Add an option to use libc malloc when the target is mruby

### DIFF
--- a/include/prism_xallocator.h
+++ b/include/prism_xallocator.h
@@ -3,17 +3,30 @@
 
 #if defined(MRC_TARGET_MRUBY)
   #include "mruby.h"
-  extern mrb_state *global_mrb;
 
-  #define xmalloc(size)             mrb_malloc(global_mrb, size)
-  #define xcalloc(nmemb,size)       mrb_calloc(global_mrb, nmemb, size)
-  #define xrealloc(ptr,size)        mrb_realloc(global_mrb, ptr, size)
-  #define xfree(ptr)                mrb_free(global_mrb, ptr)
+  #if defined(MRC_ALLOC_LIBC)
+    #define xmalloc(size)             malloc(size)
+    #define xcalloc(nmemb,size)       calloc(nmemb, size)
+    #define xrealloc(nmemb,size)      realloc(nmemb, size)
+    #define xfree(ptr)                free(ptr)
 
-  #define mrc_malloc(c,size)        mrb_malloc(c->mrb, size)
-  #define mrc_calloc(c,nmemb,size)  mrb_calloc(c->mrb, nmemb, size)
-  #define mrc_realloc(c,ptr,size)   mrb_realloc(c->mrb, ptr, size)
-  #define mrc_free(c,ptr)           mrb_free(c->mrb, ptr)
+    #define mrc_malloc(c,size)        malloc(size)
+    #define mrc_calloc(c,nmemb,size)  calloc(nmemb, size)
+    #define mrc_realloc(c,ptr,size)   realloc(ptr, size)
+    #define mrc_free(c,ptr)           free(ptr)
+  #else
+    extern mrb_state *global_mrb;
+
+    #define xmalloc(size)             mrb_malloc(global_mrb, size)
+    #define xcalloc(nmemb,size)       mrb_calloc(global_mrb, nmemb, size)
+    #define xrealloc(ptr,size)        mrb_realloc(global_mrb, ptr, size)
+    #define xfree(ptr)                mrb_free(global_mrb, ptr)
+
+    #define mrc_malloc(c,size)        mrb_malloc(c->mrb, size)
+    #define mrc_calloc(c,nmemb,size)  mrb_calloc(c->mrb, nmemb, size)
+    #define mrc_realloc(c,ptr,size)   mrb_realloc(c->mrb, ptr, size)
+    #define mrc_free(c,ptr)           mrb_free(c->mrb, ptr)
+  #endif
 #elif defined(MRC_TARGET_MRUBYC)
   #include "mrubyc.h"
   #if defined(MRBC_ALLOC_LIBC)


### PR DESCRIPTION
I have added an option to use the system malloc/free as the allocator even when `MRC_TARGET_MRUBY` is enabled.

I believe this is useful because even for mruby targets, there are cases where the compiler is expected to run only on the host machine.

(My specific use case is as follows:
https://github.com/hadashiA/MRubyCS

(As a side note:
Currently, when MRC_TARGET_MRUBY is used, it seems that an implementation of `extern mrb_state *global_mrb;` is required.  Since this repository does not contain that definition, it was unexpected for me at first glance.)