### PR TITLE
Bump RITE binary version to 0400 to match mruby and mrubyc 4.0.0

### DIFF
--- a/include/mrc_dump.h
+++ b/include/mrc_dump.h
@@ -36,7 +36,7 @@ int mrc_dump_irep(mrc_ccontext *c, const mrc_irep *irep, uint8_t flags, uint8_t 
 /* Binary Format Version Major:Minor */
 /*   Major: Incompatible to prior versions */
 /*   Minor: Upper-compatible to prior versions */
-#define RITE_BINARY_MAJOR_VER          "03"
+#define RITE_BINARY_MAJOR_VER          "04"
 #define RITE_BINARY_MINOR_VER          "00"
 #define RITE_BINARY_FORMAT_VER         RITE_BINARY_MAJOR_VER RITE_BINARY_MINOR_VER
 #if defined(RITE_COMPILER_NAME)


### PR DESCRIPTION
This PR bumps `RITE_BINARY_MAJOR_VER` from "03" to "04" to match.

mruby added a new opcode `OP_MATCHERR` and bumped the RITE binary version to "0400" in https://github.com/mruby/mruby/commit/2fa99a73c28e97c862ab7bc261e407f32f47c74a .
mrubyc followed this change in https://github.com/mrubyc/mrubyc/commit/0d4903e35b5ba23c0e1df130de474b8b605a8f9c , but mruby-compiler2 still outputs "0300", causing all tests to fail with "Bytecode version mismatch" when running `make test` in mrubyc.