### PR TITLE
Support RITE0400

### DIFF
--- a/include/mrc_dump.h
+++ b/include/mrc_dump.h
@@ -36,7 +36,7 @@ int mrc_dump_irep(mrc_ccontext *c, const mrc_irep *irep, uint8_t flags, uint8_t 
 /* Binary Format Version Major:Minor */
 /*   Major: Incompatible to prior versions */
 /*   Minor: Upper-compatible to prior versions */
-#define RITE_BINARY_MAJOR_VER          "03"
+#define RITE_BINARY_MAJOR_VER          "04"
 #define RITE_BINARY_MINOR_VER          "00"
 #define RITE_BINARY_FORMAT_VER         RITE_BINARY_MAJOR_VER RITE_BINARY_MINOR_VER
 #if defined(RITE_COMPILER_NAME)
@@ -46,7 +46,7 @@ int mrc_dump_irep(mrc_ccontext *c, const mrc_irep *irep, uint8_t flags, uint8_t 
 #define RITE_PARSER_NAME               "Prism"
 #define RITE_COMPILER_VERSION          "0000"
 
-#define RITE_VM_VER                    "0300"
+#define RITE_VM_VER                    "0400"
 
 #define RITE_BINARY_EOF                "END\0"
 #define RITE_SECTION_IREP_IDENT        "IREP"

--- a/include/mrc_irep.h
+++ b/include/mrc_irep.h
@@ -92,6 +92,7 @@ void mrc_irep_free(mrc_ccontext *c, mrc_irep *irep);
 #define MRC_ASPEC_KEY(a)          (((a) >> 2) & 0x1f)
 #define MRC_ASPEC_KDICT(a)        (((a) >> 1) & 0x1)
 #define MRC_ASPEC_BLOCK(a)        ((a) & 1)
+#define MRC_ASPEC_NOBLOCK(a)      (((a) >> 23) & 0x1)
 
 MRC_END_DECL
 

--- a/include/mrc_opcode.h
+++ b/include/mrc_opcode.h
@@ -13,6 +13,11 @@ enum mrb_insn {
 #undef OPCODE
 };
 
+/* backward compatibility aliases */
+#define OP_LOADI OP_LOADI8
+#define OP_LOADT OP_LOADTRUE
+#define OP_LOADF OP_LOADFALSE
+
 #define OP_L_STRICT  1
 #define OP_L_CAPTURE 2
 #define OP_L_METHOD  OP_L_STRICT

--- a/include/mrc_ops.h
+++ b/include/mrc_ops.h
@@ -15,7 +15,7 @@ operation code    operands      semantics
 OPCODE(NOP,        Z)        /* no operation */
 OPCODE(MOVE,       BB)       /* R[a] = R[b] */
 OPCODE(LOADL,      BB)       /* R[a] = Pool[b] */
-OPCODE(LOADI,      BB)       /* R[a] = mrb_int(b) */
+OPCODE(LOADI8,     BB)       /* R[a] = mrb_int(b) */
 OPCODE(LOADINEG,   BB)       /* R[a] = mrb_int(-b) */
 OPCODE(LOADI__1,   B)        /* R[a] = mrb_int(-1) */
 OPCODE(LOADI_0,    B)        /* R[a] = mrb_int(0) */
@@ -31,8 +31,8 @@ OPCODE(LOADI32,    BSS)      /* R[a] = mrb_int((b<<16)+c) */
 OPCODE(LOADSYM,    BB)       /* R[a] = Syms[b] */
 OPCODE(LOADNIL,    B)        /* R[a] = nil */
 OPCODE(LOADSELF,   B)        /* R[a] = self */
-OPCODE(LOADT,      B)        /* R[a] = true */
-OPCODE(LOADF,      B)        /* R[a] = false */
+OPCODE(LOADTRUE,   B)        /* R[a] = true */
+OPCODE(LOADFALSE,  B)        /* R[a] = false */
 OPCODE(GETGV,      BB)       /* R[a] = getglobal(Syms[b]) */
 OPCODE(SETGV,      BB)       /* setglobal(Syms[b], R[a]) */
 OPCODE(GETSV,      BB)       /* R[a] = Special[Syms[b]] */
@@ -48,6 +48,7 @@ OPCODE(SETMCNST,   BB)       /* R[a+1]::Syms[b] = R[a] */
 OPCODE(GETUPVAR,   BBB)      /* R[a] = uvget(b,c) */
 OPCODE(SETUPVAR,   BBB)      /* uvset(b,c,R[a]) */
 OPCODE(GETIDX,     B)        /* R[a] = R[a][R[a+1]] */
+OPCODE(GETIDX0,    BB)       /* R[a] = R[b][0]; a+1 for method call */
 OPCODE(SETIDX,     B)        /* R[a][R[a+1]] = R[a+2] */
 OPCODE(JMP,        S)        /* pc+=a */
 OPCODE(JMPIF,      BS)       /* if R[a] pc+=b */
@@ -57,25 +58,35 @@ OPCODE(JMPUW,      S)        /* unwind_and_jump_to(a) */
 OPCODE(EXCEPT,     B)        /* R[a] = exc */
 OPCODE(RESCUE,     BB)       /* R[b] = R[a].isa?(R[b]) */
 OPCODE(RAISEIF,    B)        /* raise(R[a]) if R[a] */
+OPCODE(MATCHERR,   B)        /* raise NoMatchingPatternError unless R[a] */
 OPCODE(SSEND,      BBB)      /* R[a] = self.send(Syms[b],R[a+1]..,R[a+n+1]:R[a+n+2]..) (c=n|k<<4) */
+OPCODE(SSEND0,     BB)       /* R[a] = self.send(Syms[b]) (no args) */
 OPCODE(SSENDB,     BBB)      /* R[a] = self.send(Syms[b],R[a+1]..,R[a+n+1]:R[a+n+2]..,&R[a+n+2k+1]) */
 OPCODE(SEND,       BBB)      /* R[a] = R[a].send(Syms[b],R[a+1]..,R[a+n+1]:R[a+n+2]..) (c=n|k<<4) */
+OPCODE(SEND0,      BB)       /* R[a] = R[a].send(Syms[b]) (no args) */
 OPCODE(SENDB,      BBB)      /* R[a] = R[a].send(Syms[b],R[a+1]..,R[a+n+1]:R[a+n+2]..,&R[a+n+2k+1]) */
 OPCODE(CALL,       Z)        /* self.call(*, **, &) (But overlay the current call frame; tailcall) */
+OPCODE(BLKCALL,    BB)       /* R[a] = R[a].call(R[a+1],... ,R[a+b]); direct block call */
 OPCODE(SUPER,      BB)       /* R[a] = super(R[a+1],... ,R[a+b+1]) */
 OPCODE(ARGARY,     BS)       /* R[a] = argument array (16=m5:r1:m5:d1:lv4) */
-OPCODE(ENTER,      W)        /* arg setup according to flags (23=m5:o5:r1:m5:k5:d1:b1) */
+OPCODE(ENTER,      W)        /* arg setup according to flags (24=n1:m5:o5:r1:m5:k5:d1:b1) */
 OPCODE(KEY_P,      BB)       /* R[a] = kdict.key?(Syms[b]) */
 OPCODE(KEYEND,     Z)        /* raise unless kdict.empty? */
 OPCODE(KARG,       BB)       /* R[a] = kdict[Syms[b]]; kdict.delete(Syms[b]) */
 OPCODE(RETURN,     B)        /* return R[a] (normal) */
 OPCODE(RETURN_BLK, B)        /* return R[a] (in-block return) */
+OPCODE(RETSELF,    Z)        /* return self */
+OPCODE(RETNIL,     Z)        /* return nil */
+OPCODE(RETTRUE,    Z)        /* return true */
+OPCODE(RETFALSE,   Z)        /* return false */
 OPCODE(BREAK,      B)        /* break R[a] */
 OPCODE(BLKPUSH,    BS)       /* R[a] = block (16=m5:r1:m5:d1:lv4) */
 OPCODE(ADD,        B)        /* R[a] = R[a]+R[a+1] */
 OPCODE(ADDI,       BB)       /* R[a] = R[a]+mrb_int(b) */
 OPCODE(SUB,        B)        /* R[a] = R[a]-R[a+1] */
 OPCODE(SUBI,       BB)       /* R[a] = R[a]-mrb_int(b) */
+OPCODE(ADDILV,     BBB)      /* R[a] = R[a]+mrb_int(c); R[b],R[b+1] for method call */
+OPCODE(SUBILV,     BBB)      /* R[a] = R[a]-mrb_int(c); R[b],R[b+1] for method call */
 OPCODE(MUL,        B)        /* R[a] = R[a]*R[a+1] */
 OPCODE(DIV,        B)        /* R[a] = R[a]/R[a+1] */
 OPCODE(EQ,         B)        /* R[a] = R[a]==R[a+1] */
@@ -108,6 +119,8 @@ OPCODE(CLASS,      BB)       /* R[a] = newclass(R[a],Syms[b],R[a+1]) */
 OPCODE(MODULE,     BB)       /* R[a] = newmodule(R[a],Syms[b]) */
 OPCODE(EXEC,       BB)       /* R[a] = blockexec(R[a],Irep[b]) */
 OPCODE(DEF,        BB)       /* R[a].newmethod(Syms[b],R[a+1]); R[a] = Syms[b] */
+OPCODE(TDEF,       BBB)      /* target_class.newmethod(Syms[b],Irep[c]); R[a] = Syms[b] */
+OPCODE(SDEF,       BBB)      /* R[a].singleton_class.newmethod(Syms[b],Irep[c]); R[a] = Syms[b] */
 OPCODE(ALIAS,      BB)       /* alias_method(target_class,Syms[a],Syms[b]) */
 OPCODE(UNDEF,      B)        /* undef_method(target_class,Syms[a]) */
 OPCODE(SCLASS,     B)        /* R[a] = R[a].singleton_class */

--- a/include/mrc_proc.h
+++ b/include/mrc_proc.h
@@ -5,7 +5,6 @@ MRC_BEGIN_DECL
 
 #define MRC_OBJECT_HEADER \
   struct RClass *c;       \
-  struct RBasic *gcnext;  \
   enum mrb_vtype tt:8;    \
   unsigned int gc_color:3; \
   unsigned int frozen:1;  \

--- a/src/cdump.c
+++ b/src/cdump.c
@@ -571,7 +571,7 @@ mrc_dump_irep_cstruct(mrc_ccontext *c, const mrc_irep *irep, uint8_t flags, FILE
                                       "extern\n"
                                       "#endif",
           initname);
-  fprintf(fp, "NULL,NULL,MRB_TT_PROC,MRB_GC_RED,MRB_OBJ_IS_FROZEN,0,{&%s_irep_0},NULL,{NULL},\n}};\n", initname);
+  fprintf(fp, "NULL,MRB_TT_PROC,MRB_GC_RED,MRB_OBJ_IS_FROZEN,0,{&%s_irep_0},NULL,{NULL},\n}};\n", initname);
   fputs("static void\n", fp);
   fprintf(fp, "%s_init_syms(mrb_state *mrb)\n", initname);
   fputs("{\n", fp);

--- a/src/codedump.c
+++ b/src/codedump.c
@@ -220,8 +220,8 @@ codedump(mrc_ccontext *c, const mrc_irep *irep, FILE *out)
       }
       print_lv_a(c, irep, a, out);
       break;
-    CASE(OP_LOADI, BB):
-      fprintf(out, "LOADI\t\tR%d\t%d\t", a, b);
+    CASE(OP_LOADI8, BB):
+      fprintf(out, "LOADI8\t\tR%d\t%d\t", a, b);
       print_lv_a(c, irep, a, out);
       break;
     CASE(OP_LOADINEG, BB):
@@ -265,12 +265,12 @@ codedump(mrc_ccontext *c, const mrc_irep *irep, FILE *out)
       fprintf(out, "LOADSELF\tR%d\t(R0)\t", a);
       print_lv_a(c, irep, a, out);
       break;
-    CASE(OP_LOADT, B):
-      fprintf(out, "LOADT\t\tR%d\t(true)\t", a);
+    CASE(OP_LOADTRUE, B):
+      fprintf(out, "LOADTRUE\tR%d\t(true)\t", a);
       print_lv_a(c, irep, a, out);
       break;
-    CASE(OP_LOADF, B):
-      fprintf(out, "LOADF\t\tR%d\t(false)\t", a);
+    CASE(OP_LOADFALSE, B):
+      fprintf(out, "LOADFALSE\tR%d\t(false)\t", a);
       print_lv_a(c, irep, a, out);
       break;
     CASE(OP_GETGV, BB):
@@ -332,6 +332,9 @@ codedump(mrc_ccontext *c, const mrc_irep *irep, FILE *out)
     CASE(OP_GETIDX, B):
       fprintf(out, "GETIDX\tR%d\tR%d\n", a, a+1);
       break;
+    CASE(OP_GETIDX0, BB):
+      fprintf(out, "GETIDX0\tR%d\tR%d[0]\n", a, b);
+      break;
     CASE(OP_SETIDX, B):
       fprintf(out, "SETIDX\tR%d\tR%d\tR%d\n", a, a+1, a+2);
       break;
@@ -362,6 +365,9 @@ codedump(mrc_ccontext *c, const mrc_irep *irep, FILE *out)
       fprintf(out, "SSEND\t\tR%d\t:%s\t", a, mrc_sym_dump(c, irep->syms[b]));
       print_args(cc, out);
       break;
+    CASE(OP_SSEND0, BB):
+      fprintf(out, "SSEND0\tR%d\t:%s\n", a, mrc_sym_dump(c, irep->syms[b]));
+      break;
     CASE(OP_SSENDB, BBB):
       fprintf(out, "SSENDB\tR%d\t:%s\t", a, mrc_sym_dump(c, irep->syms[b]));
       print_args(cc, out);
@@ -370,12 +376,18 @@ codedump(mrc_ccontext *c, const mrc_irep *irep, FILE *out)
       fprintf(out, "SEND\t\tR%d\t:%s\t", a, mrc_sym_dump(c, irep->syms[b]));
       print_args(cc, out);
       break;
+    CASE(OP_SEND0, BB):
+      fprintf(out, "SEND0\t\tR%d\t:%s\n", a, mrc_sym_dump(c, irep->syms[b]));
+      break;
     CASE(OP_SENDB, BBB):
       fprintf(out, "SENDB\t\tR%d\t:%s\t", a, mrc_sym_dump(c, irep->syms[b]));
       print_args(cc, out);
       break;
     CASE(OP_CALL, Z):
       fprintf(out, "CALL\n");
+      break;
+    CASE(OP_BLKCALL, BB):
+      fprintf(out, "BLKCALL\t\tR%d\t%d\n", a, b);
       break;
     CASE(OP_SUPER, BB):
       fprintf(out, "SUPER\t\tR%d\t", a);
@@ -391,7 +403,8 @@ codedump(mrc_ccontext *c, const mrc_irep *irep, FILE *out)
       print_lv_a(c, irep, a, out);
       break;
     CASE(OP_ENTER, W):
-      fprintf(out, "ENTER\t\t%d:%d:%d:%d:%d:%d:%d (0x%x)\n",
+      fprintf(out, "ENTER\t\t%d:%d:%d:%d:%d:%d:%d:%d (0x%x)\n",
+              MRC_ASPEC_NOBLOCK(a),
               MRC_ASPEC_REQ(a),
               MRC_ASPEC_OPT(a),
               MRC_ASPEC_REST(a),
@@ -418,6 +431,18 @@ codedump(mrc_ccontext *c, const mrc_irep *irep, FILE *out)
     CASE(OP_RETURN_BLK, B):
       fprintf(out, "RETURN_BLK\tR%d\t\t", a);
       print_lv_a(c, irep, a, out);
+      break;
+    CASE(OP_RETSELF, Z):
+      fprintf(out, "RETSELF\n");
+      break;
+    CASE(OP_RETNIL, Z):
+      fprintf(out, "RETNIL\n");
+      break;
+    CASE(OP_RETTRUE, Z):
+      fprintf(out, "RETTRUE\n");
+      break;
+    CASE(OP_RETFALSE, Z):
+      fprintf(out, "RETFALSE\n");
       break;
     CASE(OP_BREAK, B):
       fprintf(out, "BREAK\t\tR%d\t\t", a);
@@ -450,6 +475,12 @@ codedump(mrc_ccontext *c, const mrc_irep *irep, FILE *out)
     CASE(OP_DEF, BB):
       fprintf(out, "DEF\t\tR%d\t:%s\n", a, mrc_sym_dump(c, irep->syms[b]));
       break;
+    CASE(OP_TDEF, BBB):
+      fprintf(out, "TDEF\t\tR%d\t:%s\tI[%d]\n", a, mrc_sym_dump(c, irep->syms[b]), cc);
+      break;
+    CASE(OP_SDEF, BBB):
+      fprintf(out, "SDEF\t\tR%d\t:%s\tI[%d]\n", a, mrc_sym_dump(c, irep->syms[b]), cc);
+      break;
     CASE(OP_UNDEF, B):
       fprintf(out, "UNDEF\t\t:%s\n", mrc_sym_dump(c, irep->syms[a]));
       break;
@@ -468,6 +499,14 @@ codedump(mrc_ccontext *c, const mrc_irep *irep, FILE *out)
       break;
     CASE(OP_SUBI, BB):
       fprintf(out, "SUBI\t\tR%d\t%d\t", a, b);
+      print_lv_a(c, irep, a, out);
+      break;
+    CASE(OP_ADDILV, BBB):
+      fprintf(out, "ADDILV\tR%d\tR%d\t%d", a, b, cc);
+      print_lv_a(c, irep, a, out);
+      break;
+    CASE(OP_SUBILV, BBB):
+      fprintf(out, "SUBILV\tR%d\tR%d\t%d", a, b, cc);
       print_lv_a(c, irep, a, out);
       break;
     CASE(OP_MUL, B):
@@ -597,6 +636,9 @@ codedump(mrc_ccontext *c, const mrc_irep *irep, FILE *out)
     CASE(OP_RAISEIF, B):
       fprintf(out, "RAISEIF\tR%d\t\t", a);
       print_lv_a(c, irep, a, out);
+      break;
+    CASE(OP_MATCHERR, B):
+      fprintf(out, "MATCHERR\tR%d\n", a);
       break;
 
     CASE(OP_DEBUG, BBB):

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -794,7 +794,7 @@ get_int_operand(mrc_codegen_scope *s, struct mrc_insn_data *data, mrc_int *n)
     *n = data->insn - OP_LOADI_0;
     return TRUE;
 
-  case OP_LOADI:
+  case OP_LOADI8:
   case OP_LOADI16:
     *n = (int16_t)data->b;
     return TRUE;
@@ -879,7 +879,7 @@ genjmp2(mrc_codegen_scope *s, mrc_code i, uint16_t a, uint32_t pc, int val)
       }
       break;
     case OP_LOADNIL:
-    case OP_LOADF:
+    case OP_LOADFALSE:
       if (data.a == a || data.a > s->nlocals) {
         s->pc = addr_pc(s, data.addr);
         if (i == OP_JMPNOT || (i == OP_JMPNIL && data.insn == OP_LOADNIL)) {
@@ -890,7 +890,7 @@ genjmp2(mrc_codegen_scope *s, mrc_code i, uint16_t a, uint32_t pc, int val)
         }
       }
       break;
-    case OP_LOADT: case OP_LOADI: case OP_LOADINEG: case OP_LOADI__1:
+    case OP_LOADTRUE: case OP_LOADI8: case OP_LOADINEG: case OP_LOADI__1:
     case OP_LOADI_0: case OP_LOADI_1: case OP_LOADI_2: case OP_LOADI_3:
     case OP_LOADI_4: case OP_LOADI_5: case OP_LOADI_6: case OP_LOADI_7:
       if (data.a == a || data.a > s->nlocals) {
@@ -936,7 +936,7 @@ gen_int(mrc_codegen_scope *s, uint16_t dst, mrc_int i)
     else goto int_lit;
   }
   else if (i < 8) genop_1(s, OP_LOADI_0 + (uint8_t)i, dst);
-  else if (i <= 0xff) genop_2(s, OP_LOADI, dst, (uint16_t)i);
+  else if (i <= 0xff) genop_2(s, OP_LOADI8, dst, (uint16_t)i);
   else if (i <= INT16_MAX) genop_2S(s, OP_LOADI16, dst, (uint16_t)i);
   else if (i <= INT32_MAX) genop_2SS(s, OP_LOADI32, dst, (uint32_t)i);
   else {
@@ -972,7 +972,7 @@ gen_move(mrc_codegen_scope *s, uint16_t dst, uint16_t src, int nopeep)
         return;
       }
       goto normal;
-    case OP_LOADNIL: case OP_LOADSELF: case OP_LOADT: case OP_LOADF:
+    case OP_LOADNIL: case OP_LOADSELF: case OP_LOADTRUE: case OP_LOADFALSE:
     case OP_LOADI__1:
     case OP_LOADI_0: case OP_LOADI_1: case OP_LOADI_2: case OP_LOADI_3:
     case OP_LOADI_4: case OP_LOADI_5: case OP_LOADI_6: case OP_LOADI_7:
@@ -983,7 +983,7 @@ gen_move(mrc_codegen_scope *s, uint16_t dst, uint16_t src, int nopeep)
     case OP_HASH:
       if (data.b != 0) goto normal;
       /* fall through */
-    case OP_LOADI: case OP_LOADINEG:
+    case OP_LOADI8: case OP_LOADINEG:
     case OP_LOADL: case OP_LOADSYM:
     case OP_GETGV: case OP_GETSV: case OP_GETIV: case OP_GETCV:
     case OP_GETCONST: case OP_STRING:

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1032,17 +1032,21 @@ gen_move(mrc_codegen_scope *s, uint16_t dst, uint16_t src, int nopeep)
         s->pc = addr_pc(s, data0.addr);
         if (addr_pc(s, data0.addr) != s->lastlabel) {
           /* constant folding */
-          data0 = mrc_decode_insn(mrc_prev_pc(s, data0.addr));
+          struct mrc_insn_data data1 = mrc_decode_insn(mrc_prev_pc(s, data0.addr));
           mrc_int n;
-          if (data0.a == dst && get_int_operand(s, &data0, &n)) {
+          if (data1.a == dst && get_int_operand(s, &data1, &n)) {
             if ((data.insn == OP_ADDI && !mrc_int_add_overflow(n, data.b, &n)) ||
                 (data.insn == OP_SUBI && !mrc_int_sub_overflow(n, data.b, &n))) {
-              s->pc = addr_pc(s, data0.addr);
+              s->pc = addr_pc(s, data1.addr);
               gen_int(s, dst, n);
               return;
             }
           }
         }
+        /* ADDILV/SUBILV fusion: MOVE temp local; ADDI/SUBI temp imm; MOVE local temp */
+        /* -> ADDILV/SUBILV local temp imm (temp is working space for method fallback) */
+        genop_3(s, data.insn == OP_ADDI ? OP_ADDILV : OP_SUBILV, dst, data.a, data.b);
+        return;
       }
       genop_2(s, data.insn, dst, data.b);
       return;
@@ -1178,7 +1182,28 @@ gen_return(mrc_codegen_scope *s, uint8_t op, uint16_t src)
       rewind_pc(s);
       genop_1(s, op, data.b);
     }
-    else if (data.insn != OP_RETURN) {
+    else if (data.insn == OP_LOADSELF && src == data.a && op == OP_RETURN) {
+      /* LOADSELF + RETURN -> RETSELF */
+      rewind_pc(s);
+      genop_0(s, OP_RETSELF);
+    }
+    else if (data.insn == OP_LOADNIL && src == data.a && op == OP_RETURN) {
+      /* LOADNIL + RETURN -> RETNIL */
+      rewind_pc(s);
+      genop_0(s, OP_RETNIL);
+    }
+    else if (data.insn == OP_LOADTRUE && src == data.a && op == OP_RETURN) {
+      /* LOADTRUE + RETURN -> RETTRUE */
+      rewind_pc(s);
+      genop_0(s, OP_RETTRUE);
+    }
+    else if (data.insn == OP_LOADFALSE && src == data.a && op == OP_RETURN) {
+      /* LOADFALSE + RETURN -> RETFALSE */
+      rewind_pc(s);
+      genop_0(s, OP_RETFALSE);
+    }
+    else if (data.insn != OP_RETURN && data.insn != OP_RETSELF && data.insn != OP_RETNIL &&
+             data.insn != OP_RETTRUE && data.insn != OP_RETFALSE) {
       genop_1(s, op, src);
     }
   }
@@ -1402,6 +1427,16 @@ gen_binop(mrc_codegen_scope *s, mrc_sym op, uint16_t dst)
 {
   if (no_peephole(s)) return FALSE;
   else if (op == MRC_OPSYM_2(aref)) {
+    /* GETIDX0 fusion: MOVE dst arr; LOADI_0 dst+1 -> GETIDX0 dst arr */
+    struct mrc_insn_data data = mrc_last_insn(s);
+    if (data.insn == OP_LOADI_0 && data.a == dst+1 && addr_pc(s, data.addr) != s->lastlabel) {
+      struct mrc_insn_data data0 = mrc_decode_insn(mrc_prev_pc(s, data.addr));
+      if (data0.insn == OP_MOVE && data0.a == dst && data0.b != dst) {
+        s->pc = addr_pc(s, data0.addr);
+        genop_2(s, OP_GETIDX0, dst, data0.b);
+        return TRUE;
+      }
+    }
     genop_1(s, OP_GETIDX, dst);
     return TRUE;
   }

--- a/src/codegen_prism.inc
+++ b/src/codegen_prism.inc
@@ -593,8 +593,16 @@ gen_call(mrc_codegen_scope *s, mrc_node *tree, int val, int safe)
     /* constant folding succeeded */
   }
   else if (noself) {
-    genop_3(s, blk ? OP_SSENDB : OP_SSEND, cursp(), new_sym(s, sym), n|(nk<<4));
+    if (!blk && n == 0 && nk == 0) {
+      genop_2(s, OP_SSEND0, cursp(), new_sym(s, sym));
     }
+    else {
+      genop_3(s, blk ? OP_SSENDB : OP_SSEND, cursp(), new_sym(s, sym), n|(nk<<4));
+    }
+  }
+  else if (!blk && n == 0 && nk == 0) {
+    genop_2(s, OP_SEND0, cursp(), new_sym(s, sym));
+  }
   else {
     genop_3(s, blk ? OP_SENDB : OP_SEND, cursp(), new_sym(s, sym), n|(nk<<4));
   }
@@ -2192,19 +2200,35 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       int idx = lambda_body(s, (mrc_node *)cast, cast->body, &cast->locals, 0);
 
       if (cast->receiver == NULL) {
-        genop_1(s, OP_TCLASS, cursp());
-        push();
+        if (idx <= 0xff) {
+          /* TDEF fusion: TCLASS + METHOD + DEF -> TDEF */
+          genop_3(s, OP_TDEF, cursp(), sym, idx);
+        }
+        else {
+          genop_1(s, OP_TCLASS, cursp());
+          push();
+          genop_2(s, OP_METHOD, cursp(), idx);
+          push(); pop();
+          pop();
+          genop_2(s, OP_DEF, cursp(), sym);
+        }
       }
       else {
         codegen(s, cast->receiver, VAL);
         pop();
-        genop_1(s, OP_SCLASS, cursp());
-        push();
+        if (idx <= 0xff) {
+          /* SDEF fusion: SCLASS + METHOD + DEF -> SDEF */
+          genop_3(s, OP_SDEF, cursp(), sym, idx);
+        }
+        else {
+          genop_1(s, OP_SCLASS, cursp());
+          push();
+          genop_2(s, OP_METHOD, cursp(), idx);
+          push(); pop();
+          pop();
+          genop_2(s, OP_DEF, cursp(), sym);
+        }
       }
-      genop_2(s, OP_METHOD, cursp(), idx);
-      push(); pop();
-      pop();
-      genop_2(s, OP_DEF, cursp(), sym);
       if (val) push();
       break;
     }
@@ -2800,7 +2824,14 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
       pop_n(n+1);
       genop_2S(s, OP_BLKPUSH, cursp(), (ainfo<<4)|(lv & 0xf));
       if (sendv) n = CALL_MAXARGS;
-      genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_SYM_1(call)), n);
+      if (n < 15) {
+        /* fast path: direct block call without method dispatch */
+        genop_2(s, OP_BLKCALL, cursp(), n);
+      }
+      else {
+        /* fallback: use SEND for splat */
+        genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_SYM_1(call)), n);
+      }
       if (val) push();
       break;
     }

--- a/src/codegen_prism.inc
+++ b/src/codegen_prism.inc
@@ -1753,7 +1753,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
             lp->type = LOOP_RESCUE;
             catch_handler_set(s, catch_entry, MRC_CATCH_RESCUE, begin, end, s->pc);
             genop_1(s, OP_EXCEPT, exc);
-            genop_1(s, OP_LOADF, exc);
+            genop_1(s, OP_LOADFALSE, exc);
             dispatch(s, noexc);
             loop_pop(s, NOVAL);
             break;
@@ -2500,7 +2500,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     case PM_TRUE_NODE:
     {
       if (val) {
-        genop_1(s, OP_LOADT, cursp());
+        genop_1(s, OP_LOADTRUE, cursp());
         push();
       }
       break;
@@ -2508,7 +2508,7 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     case PM_FALSE_NODE:
     {
       if (val) {
-        genop_1(s, OP_LOADF, cursp());
+        genop_1(s, OP_LOADFALSE, cursp());
         push();
       }
       break;

--- a/test/array_test.rb
+++ b/test/array_test.rb
@@ -46,4 +46,26 @@ class ArrayTest < Picotest::Test
     actual = run_script(script)
     assert_equal("[0, 1, 2, 3, 44]", actual)
   end
+
+  def test_index_zero
+    script = <<~RUBY
+      ary = [10, 20, 30]
+      p ary[0]
+    RUBY
+    actual = run_script(script)
+    assert_equal("10", actual)
+  end
+
+  def test_index_zero_in_loop
+    script = <<~RUBY
+      pairs = [[1, 2], [3, 4], [5, 6]]
+      i = 0
+      while i < pairs.size
+        p pairs[i][0]
+        i += 1
+      end
+    RUBY
+    actual = run_script(script)
+    assert_equal("1\n3\n5", actual)
+  end
 end

--- a/test/def_test.rb
+++ b/test/def_test.rb
@@ -171,4 +171,51 @@ class DefTest < Picotest::Test
     actual = run_script(script)
     assert_equal("1\nnil\n[2, 3]", actual)
   end
+
+  def test_return_self
+    script = <<~RUBY
+      class Foo
+        def me
+          self
+        end
+      end
+      foo = Foo.new
+      p foo.me.object_id==foo.object_id
+    RUBY
+    actual = run_script(script)
+    assert_equal("true", actual)
+  end
+
+  def test_return_nil
+    script = <<~RUBY
+      def m
+        nil
+      end
+      p m
+    RUBY
+    actual = run_script(script)
+    assert_equal("nil", actual)
+  end
+
+  def test_return_true
+    script = <<~RUBY
+      def m
+        true
+      end
+      p m
+    RUBY
+    actual = run_script(script)
+    assert_equal("true", actual)
+  end
+
+  def test_return_false
+    script = <<~RUBY
+      def m
+        false
+      end
+      p m
+    RUBY
+    actual = run_script(script)
+    assert_equal("false", actual)
+  end
 end

--- a/test/op_assign_test.rb
+++ b/test/op_assign_test.rb
@@ -36,4 +36,41 @@ class OpAssignTest < Picotest::Test
     actual = run_script(script)
     assert_equal("1", actual)
   end
+
+  def test_local_var_add_assign
+    script = <<~RUBY
+      i = 0
+      i += 1
+      i += 1
+      i += 1
+      p i
+    RUBY
+    actual = run_script(script)
+    assert_equal("3", actual)
+  end
+
+  def test_local_var_sub_assign
+    script = <<~RUBY
+      i = 10
+      i -= 3
+      i -= 2
+      p i
+    RUBY
+    actual = run_script(script)
+    assert_equal("5", actual)
+  end
+
+  def test_local_var_add_assign_in_loop
+    script = <<~RUBY
+      sum = 0
+      i = 0
+      while i < 5
+        sum += i
+        i += 1
+      end
+      p sum
+    RUBY
+    actual = run_script(script)
+    assert_equal("10", actual)
+  end
 end

--- a/test/yield_test.rb
+++ b/test/yield_test.rb
@@ -54,4 +54,27 @@ class YieldTest < Picotest::Test
     actual = run_script(script)
     assert_equal("Hello Ruby", actual)
   end
+
+  def test_yield_no_args
+    script = <<~'RUBY'
+      def m
+        yield
+      end
+      m { puts "called" }
+    RUBY
+    actual = run_script(script)
+    assert_equal("called", actual)
+  end
+
+  def test_yield_no_args_with_return_value
+    script = <<~'RUBY'
+      def m
+        result = yield
+        puts result
+      end
+      m { 42 }
+    RUBY
+    actual = run_script(script)
+    assert_equal("42", actual)
+  end
 end


### PR DESCRIPTION
This pull request upgrades the RITE version to 0400, introducing several updates and new features to the VM instruction set and supporting code, including opcode renaming for clarity, new opcodes for improved expressiveness, and adjustments to binary and VM versioning. The changes also include enhancements for argument specification, new instruction handling in the code generator, and improved compatibility and maintainability.

**Opcode and Instruction Set Updates:**

* Renamed several opcodes for clarity: `OP_LOADI` → `OP_LOADI8`, `OP_LOADT`/`OP_LOADF` → `OP_LOADTRUE`/`OP_LOADFALSE`. Backward compatibility aliases are provided for the old names. [[1]](diffhunk://#diff-b5d3e4c83f8c05b0c357068203d3c2ccfce19befd67da76e3afd337b9aae5e87L18-R18) [[2]](diffhunk://#diff-b5d3e4c83f8c05b0c357068203d3c2ccfce19befd67da76e3afd337b9aae5e87L34-R35) [[3]](diffhunk://#diff-da429429ad5f178176efeebf66f0af636266037cdcce9566b60115d4f54ecfa7R16-R20)
* Added new opcodes: `OP_GETIDX0`, `OP_SSEND0`, `OP_SEND0`, `OP_BLKCALL`, `OP_MATCHERR`, `OP_RETSELF`, `OP_RETNIL`, `OP_RETTRUE`, `OP_RETFALSE`, `OP_ADDILV`, `OP_SUBILV`, `OP_TDEF`, `OP_SDEF` to support new VM features and optimizations. [[1]](diffhunk://#diff-b5d3e4c83f8c05b0c357068203d3c2ccfce19befd67da76e3afd337b9aae5e87R51) [[2]](diffhunk://#diff-b5d3e4c83f8c05b0c357068203d3c2ccfce19befd67da76e3afd337b9aae5e87R61-R89) [[3]](diffhunk://#diff-b5d3e4c83f8c05b0c357068203d3c2ccfce19befd67da76e3afd337b9aae5e87R122-R123)
* Updated the handling and display of new and renamed opcodes in `codedump.c` and `codegen.c`, including constant folding and opcode fusion for arithmetic operations. [[1]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707L223-R224) [[2]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707L268-R273) [[3]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707R335-R337) [[4]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707R368-R370) [[5]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707R379-R391) [[6]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707L394-R407) [[7]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707R435-R446) [[8]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707R478-R483) [[9]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707R504-R511) [[10]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707R640-R642) [[11]](diffhunk://#diff-16ac7ad9254569a414077f1a3b8afe0b04bd34eb40c141736245a766b0d099f2L797-R797) [[12]](diffhunk://#diff-16ac7ad9254569a414077f1a3b8afe0b04bd34eb40c141736245a766b0d099f2L882-R882) [[13]](diffhunk://#diff-16ac7ad9254569a414077f1a3b8afe0b04bd34eb40c141736245a766b0d099f2L893-R893) [[14]](diffhunk://#diff-16ac7ad9254569a414077f1a3b8afe0b04bd34eb40c141736245a766b0d099f2L939-R939) [[15]](diffhunk://#diff-16ac7ad9254569a414077f1a3b8afe0b04bd34eb40c141736245a766b0d099f2L975-R975) [[16]](diffhunk://#diff-16ac7ad9254569a414077f1a3b8afe0b04bd34eb40c141736245a766b0d099f2L986-R986) [[17]](diffhunk://#diff-16ac7ad9254569a414077f1a3b8afe0b04bd34eb40c141736245a766b0d099f2L1035-R1049)

**Binary and VM Versioning:**

* Incremented the binary format major version (`RITE_BINARY_MAJOR_VER` from "03" to "04") and VM version (`RITE_VM_VER` from "0300" to "0400") to reflect breaking changes in the instruction set. [[1]](diffhunk://#diff-bedfcecb3c165a3798ceb127b2e6698a4801e0f1e0ef6ee037cee3f8aad2b849L39-R39) [[2]](diffhunk://#diff-bedfcecb3c165a3798ceb127b2e6698a4801e0f1e0ef6ee037cee3f8aad2b849L49-R49)

**Argument Specification Improvements:**

* Added `MRC_ASPEC_NOBLOCK` macro for argument specification and updated the `OP_ENTER` instruction to use an additional argument flag. [[1]](diffhunk://#diff-d6219852cdba28ac4a602e57ce18d8f425f33851cf33b7542052031043903968R95) [[2]](diffhunk://#diff-b5d3e4c83f8c05b0c357068203d3c2ccfce19befd67da76e3afd337b9aae5e87R61-R89) [[3]](diffhunk://#diff-10e8cefe5ac6b256a2736fce371da6f57da52ac88eb6c291da0f57ef20576707L394-R407)

**Codebase Maintenance and Compatibility:**

* Removed the unused `gcnext` field from the `MRC_OBJECT_HEADER` macro in `mrc_proc.h` for cleanup.
* Updated code generation and dump logic to match the new instruction set and object header structure.

These changes collectively modernize the VM instruction set, improve maintainability, and add new capabilities for future development.