### PR TITLE
 Fix OP_GETGV symbol encoding for $&, $\, $', $1..$9`    

### DIFF
--- a/src/codegen_prism.inc
+++ b/src/codegen_prism.inc
@@ -2024,7 +2024,8 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     case PM_BACK_REFERENCE_READ_NODE:
     {
       if (val) {
-        int sym = new_sym(s, MRC_SYM_2(back_ref));
+        CAST(back_reference_read);
+        int sym = new_sym(s, cast->name);
         genop_2(s, OP_GETGV, cursp(), sym);
         push();
       }
@@ -2034,10 +2035,13 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
     {
       if (val) {
         CAST(numbered_reference_read);
-        char buf[100];
+        char buf[16];
         buf[0] = '$';
-        sprintf(buf+1, "%d", cast->number);
-        int sym = new_sym(s, nsym(s->c->p, (const uint8_t *)buf, strlen(buf)));
+        int n = snprintf(buf + 1, sizeof(buf) - 1, "%u", (unsigned int)cast->number);
+        size_t len = (size_t)(1 + n);  // leading '$' + digits
+        uint8_t *name = (uint8_t *)mrc_malloc(s->c, len);
+        memcpy(name, buf, len);
+        int sym = new_sym(s, pm_constant_pool_insert_owned(&s->c->p->constant_pool, name, len));
         genop_2(s, OP_GETGV, cursp(), sym);
         push();
       }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                  
                                                   
  `codegen_prism.inc` mis-encodes two kinds of global-variable reads in                                                                                                                                                       
  `OP_GETGV` operands:                                                                                                                                                                                                        
                                                                                                                                                                                                                              
  1. **Back-references** (`$&`, `` $` ``, `$'`, `$+`) all use                                                                                                                                                                 
     `MRC_SYM_2(back_ref)`, the presym bound to the literal `"$+"`, so
     every back-reference collapses to `"$+"` in the dumped bytecode.                                                                                                                                                         
                                                                      
  2. **Numbered references** (`$1`..`$9`) build the name in a local stack                                                                                                                                                     
     buffer and hand the pointer to `pm_constant_pool_insert_constant`,
     which **stores the pointer without copying**. After the codegen                                                                                                                                                          
     function returns the buffer is reused, so the dumped symbol bytes
     are garbage (we observed `\x08G` for `$1`).                                                                                                                                                                              
                                                                      
  ## Reproduce                                                                                                                                                                                                                
                                                                      
  ```ruby
  /world/ =~ 'hello world'
  p $`, $&, $+, $1
  ```                                                                                                                                                                                                                         
   
  ```sh                                                                                                                                                                                                                       
  $ mrbc -v repro.rb                                                  
  ... GETGV  R2  $+    # was $` in source
  ... GETGV  R2  $+    # was $& in source
  ... GETGV  R2  $+
  ... GETGV  R2  G     # garbage; was $1 in source                                                                                                                                                                            
  ```
                                                                                                                                                                                                                              
  ## Fix                                                              

  - Back-reference: use `cast->name` (the Prism constant_id for the actual                                                                                                                                                    
    token bytes — already in the pool).
  - Numbered reference: `mrc_malloc` a heap copy and hand ownership to the                                                                                                                                                    
    pool via `pm_constant_pool_insert_owned`.                         
                                               