### PR TITLE
Optimization: don't emit a dead OP_APOST for trailing-comma masgn

### DIFF
--- a/src/codegen_prism.inc
+++ b/src/codegen_prism.inc
@@ -599,6 +599,7 @@ gen_massignment(mrc_codegen_scope *s, mrc_node *tree, int rhs, int val)
 {
   CAST(multi_write);
   int n = cast->lefts.size, post = cast->rights.size;
+  int has_rest = cast->rest && nint(cast->rest) != PM_IMPLICIT_REST_NODE;
 
   if (0 < n) { /* pre */
     for (int i = 0; i < n; i++) {
@@ -609,12 +610,12 @@ gen_massignment(mrc_codegen_scope *s, mrc_node *tree, int rhs, int val)
       pop();
     }
   }
-  if (cast->rest || 0 < post) {
+  if (has_rest || 0 < post) {
     gen_move(s, cursp(), rhs, val);
     push_n(post+1);
     pop_n(post+1);
     genop_3(s, OP_APOST, cursp(), n, post);
-    if (cast->rest && nint(cast->rest) != PM_IMPLICIT_REST_NODE) { /* rest */
+    if (has_rest) { /* rest */
       pm_node_t *rest_expr = ((pm_splat_node_t *)cast->rest)->expression;
       if (rest_expr) {
         gen_assignment(s, rest_expr, NULL, cursp(), NOVAL);


### PR DESCRIPTION
The syntax `a, b, = expr` (with a trailing comma) is parsed as a multiple assignment that discards extra values, making it functionally identical to a, b = expr.

Currently, `gen_massignment()` emitted an `OP_APOST` instruction for this pattern. 

Since the resulting register was immediately overwritten without being read, this created a dead instruction that needlessly allocated a temporary rest Array every time. In contrast, the upstream mrbc only emits AREF instructions.

e.g.)

```ruby
arr = [1, 2, 3]
a, b, = arr
```

mruby-compiler2
```
  AREF   R2 R4 0
  AREF   R3 R4 1
  MOVE   R5 R4
  APOST  R5 2 0
  MOVE   R5 R4
  RETURN R4
```

mrbc
```
AREF   R2 R4 0
AREF   R3 R4 1
RETURN R4
```

### Fix

In `gen_massignment()` treat an implicit rest as "no rest" — only emit `OP_APOST` when
there's a named/explicit rest or post targets:

```c
int has_rest = cast->rest && nint(cast->rest) != PM_IMPLICIT_REST_NODE;
if (has_rest || 0 < post) { ... if (has_rest) { ...assign rest... } ... }
```

(The fixed-RHS path already handled implicit rest; only the variable-RHS path was wrong.)

## Note

- Removes one instruction + one rest-Array allocation per `a, b, = expr`. 
- In [optcarrot](https://github.com/mame/optcarrot), on a mruby VM using this compiler, that one hot per-fetch line was ~84% of per-frame
allocation; the fix removes it with identical output.


