### PR TITLE
codegen: Pass keyword arguments through yield to block parameters

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -5713,25 +5713,38 @@ codegen(mrc_codegen_scope *s, mrc_node *tree, int val)
         ainfo = (int)s2->ainfo;
       }
       if (ainfo < 0) codegen_error(s, "invalid yield (SyntaxError)");
-      push();
+      int nk = 0;
+      int sp_save = cursp();
+      push(); /* slot for the block (call receiver) */
       if (cast->arguments) {
-        n = gen_values(s, (mrc_node *)cast->arguments, VAL, 14);
-        if (n < 0) {
-          n = sendv = 1;
-          push();
+        CAST3(arguments, cast->arguments, args);
+        if (args && args->arguments.size > 0) {
+          n = gen_values(s, (mrc_node *)cast->arguments, VAL, 14);
+          if (n < 0) {
+            n = sendv = 1;
+            push();
+          }
+          /* keyword arguments: gather like a normal call so the block's
+           * keyword parameters bind (yield(label: x) -> { |label:| }) */
+          for (size_t i = 0; i < args->arguments.size; i++) {
+            if (nint(args->arguments.nodes[i]) == PM_KEYWORD_HASH_NODE) {
+              nk = gen_hash(s, (mrc_node *)args->arguments.nodes[i], VAL, 14);
+              if (nk < 0) nk = 15;
+            }
+          }
         }
       }
-      push(); pop(); /* space for a block */
-      pop_n(n+1);
+      push(); pop();
+      s->sp = sp_save;
       genop_2S(s, OP_BLKPUSH, cursp(), (ainfo<<4)|(lv & 0xf));
       if (sendv) n = CALL_MAXARGS;
-      if (n < 15) {
+      if (nk == 0 && !sendv && n < 15) {
         /* fast path: direct block call without method dispatch */
         genop_2(s, OP_BLKCALL, cursp(), n);
       }
       else {
-        /* fallback: use SEND for splat */
-        genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_SYM_1(call)), n);
+        /* fallback: SEND #call (handles keyword args and splat) */
+        genop_3(s, OP_SEND, cursp(), new_sym(s, MRC_SYM_1(call)), n|(nk<<4));
       }
       if (val) push();
       break;


### PR DESCRIPTION
## Problem

`yield` codegen gathered only positional arguments and dispatched via
`OP_BLKCALL`, which carries no keyword information. So keyword arguments passed
to `yield` never reached the block's keyword parameters:

```ruby
def y; yield(label: "x"); end
y { |label:|     label }   # ArgumentError: missing keyword: label
y { |label: "d"| label }   # => "d"  (passed value ignored, default used)
```

(Lambda and method keyword arguments already worked.)

## Fix

Gather keyword arguments in the `yield` path like a normal call (`gen_hash` →
`nk`) and, when keywords (or a splat) are present, dispatch via `OP_SEND #call`
with `n|(nk<<4)` so the block's `OP_ENTER` binds them. Positional-only and
no-arg `yield`s keep the `OP_BLKCALL` fast path.

## Verification

Built into PicoRuby (host mruby):

```
def y; yield(label: "x"); end
y { |label:|     label }   # "x"
y { |label: "d"| label }   # "x"
def y2; yield(1, k: 2); end
y2 { |a, k:| [a, k] }      # [1, 2]
def y3; yield(1, 2); end
y3 { |a, b| a + b }        # 3   (positional unaffected)
def y4; yield; end
y4 { 42 }                  # 42  (no-arg unaffected)
```

Existing gem suites still pass (no codegen regression).